### PR TITLE
Enhance anonymous chat flow and admin overview

### DIFF
--- a/src/bot/handlers/anon/__init__.py
+++ b/src/bot/handlers/anon/__init__.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 from aiogram import Router
 
-from . import admin_box, dialogs, menu, public
+from . import admin_box, dialogs, menu, public, settings, consent
 
 router = Router(name="anon")
 router.include_router(menu.router)
 router.include_router(dialogs.router)
 router.include_router(admin_box.router)
 router.include_router(public.router)
+router.include_router(settings.router)
+router.include_router(consent.router)

--- a/src/bot/handlers/anon/callbacks.py
+++ b/src/bot/handlers/anon/callbacks.py
@@ -13,3 +13,12 @@ class DialogCB(CallbackData, prefix="anonchat"):
 class PublicCB(CallbackData, prefix="anonpub"):
     action: str
     request_id: int
+
+
+class PrefCB(CallbackData, prefix="anonpref"):
+    mode: str
+
+
+class ConsentCB(CallbackData, prefix="anoncons"):
+    action: str
+    request_id: int

--- a/src/bot/handlers/anon/consent.py
+++ b/src/bot/handlers/anon/consent.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import contextlib
+
+from aiogram import Router
+from aiogram.enums import ParseMode
+from aiogram.types import CallbackQuery
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from bot.utils.repo import Repo
+
+from .callbacks import ConsentCB
+from .common import (
+    cancel_all_timeouts,
+    dialog_role,
+    format_dialog_text,
+    lang,
+    notify_dialog_closed,
+    reply_keyboard,
+    schedule_reply_timeout,
+    should_show_header,
+    tr,
+)
+
+router = Router(name="anon-consent")
+
+
+@router.callback_query(ConsentCB.filter())
+async def on_consent(
+    callback: CallbackQuery,
+    callback_data: ConsentCB,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_maker() as session:
+        repo = Repo(session)
+        request = await repo.get_consent_request(callback_data.request_id)
+        if not request:
+            await callback.answer("Not found", show_alert=True)
+            return
+        if request.recipient_id != callback.from_user.id:
+            await callback.answer("Это уведомление не для вас.", show_alert=True)
+            return
+        if request.status != "pending":
+            await callback.answer("Запрос уже обработан.", show_alert=True)
+            return
+        message = await repo.get_anon_message(request.pending_message_id)
+        dialog = await repo.get_anon_dialog(request.dialog_id)
+        if not message or not dialog or dialog.status != "active":
+            await repo.update_consent_request_status(request_id=request.id, status="rejected")
+            await callback.answer("Диалог закрыт.", show_alert=True)
+            return
+
+    lang_code = lang(callback.from_user.id)
+    role = dialog_role(dialog, callback.from_user.id, as_recipient=True)
+    if callback_data.action == "accept":
+        await handle_accept(callback, session_maker, request, message, dialog, lang_code, role)
+    else:
+        await handle_reject(callback, session_maker, request, message, dialog, lang_code, role)
+
+
+async def handle_accept(callback, session_maker, request, message, dialog, lang_code, role) -> None:
+    with_header = should_show_header(dialog, callback.from_user.id)
+    async with session_maker() as session:
+        repo = Repo(session)
+        await repo.update_consent_request_status(request_id=request.id, status="approved")
+        await repo.set_dialog_consent(dialog.id, role, "approved")
+        await repo.set_message_delivered(message.id, True)
+        if with_header:
+            await repo.mark_dialog_header_sent(dialog.id, role)
+    text = format_dialog_text(dialog, message.text, lang_code, with_header=with_header)
+    try:
+        await callback.bot.edit_message_text(
+            text,
+            chat_id=callback.message.chat.id,
+            message_id=request.placeholder_message_id,
+            parse_mode=ParseMode.HTML,
+            reply_markup=reply_keyboard(dialog.dialog_code, lang_code),
+        )
+    except Exception:
+        pass
+    await callback.answer(tr(lang_code, "Сообщение принято.", "Message accepted."))
+    schedule_reply_timeout(
+        dialog,
+        waiting_for=callback.from_user.id,
+        message_id=message.id,
+        last_sender_id=message.sender_id,
+        bot=callback.bot,
+        session_maker=session_maker,
+    )
+
+
+async def handle_reject(callback, session_maker, request, message, dialog, lang_code, role) -> None:
+    async with session_maker() as session:
+        repo = Repo(session)
+        await repo.update_consent_request_status(request_id=request.id, status="rejected")
+        await repo.set_dialog_consent(dialog.id, role, "rejected")
+        await repo.close_anon_dialog(dialog.id)
+    cancel_all_timeouts(dialog.id)
+    with contextlib.suppress(Exception):
+        await callback.bot.edit_message_text(
+            tr(lang_code, "⛔️ Чат отклонён.", "⛔️ Chat declined."),
+            chat_id=callback.message.chat.id,
+            message_id=request.placeholder_message_id,
+        )
+    sender_text = tr(
+        lang(message.sender_id),
+        "Пользователь отклонил анонимный чат.",
+        "The user declined the anonymous chat.",
+    )
+    with contextlib.suppress(Exception):
+        await callback.bot.send_message(message.sender_id, sender_text)
+    await notify_dialog_closed(callback.bot, dialog, callback.from_user.id)
+    await callback.answer(tr(lang_code, "Чат отклонён.", "Chat declined."))

--- a/src/bot/handlers/anon/dialogs.py
+++ b/src/bot/handlers/anon/dialogs.py
@@ -13,13 +13,23 @@ from bot.utils.repo import Repo
 from .callbacks import DialogCB
 from .common import (
     active_dialog,
+    awaiting_consent_text,
+    cancel_all_timeouts,
+    cancel_reply_timeout,
+    consent_keyboard,
+    consent_prompt_text,
     ensure_rate,
     lang,
     main_admin_id,
     new_dialog,
     notify_dialog_closed,
+    receiver_blocked_text,
+    self_blocked_text,
+    dialog_role,
     resolve_target,
+    schedule_reply_timeout,
     send_dialog_message,
+    should_show_header,
     snapshot,
     tr,
     validation_error,
@@ -32,27 +42,41 @@ router = Router(name="anon-dialogs")
 @router.message(AnonStates.waiting_target)
 async def on_target(message: Message, state: FSMContext, session_maker: async_sessionmaker[AsyncSession]) -> None:
     lang_code = lang(message.from_user.id)
-    try:
-        target_id = await resolve_target(message.text)
-    except Exception:
-        await message.answer(tr(lang_code, "Не удалось определить пользователя. Проверь ввод.", "Could not resolve the user. Check the input."))
-        return
-    if not target_id:
-        await message.answer(tr(lang_code, "Укажи ID или @username.", "Send an ID or @username."))
-        return
-    try:
-        await ensure_rate(message.from_user.id, lang_code)
-    except ValueError as err:
-        await message.answer(str(err))
-        return
-
     async with session_maker() as session:
         repo = Repo(session)
+        try:
+            target_id = await resolve_target(repo, message.text)
+        except ValueError:
+            await message.answer(tr(lang_code, "Не удалось определить пользователя. Проверь ввод.", "Could not resolve the user. Check the input."))
+            return
+        if not target_id:
+            await message.answer(tr(lang_code, "Укажи ID или @username.", "Send an ID or @username."))
+            return
+        try:
+            await ensure_rate(message.from_user.id, lang_code)
+        except ValueError as err:
+            await message.answer(str(err))
+            return
         existing = await active_dialog(repo, message.from_user.id, kind="user")
         if existing:
             await message.answer(tr(lang_code, "Сначала завершите текущий диалог.", "Please close the active dialog first."))
             return
-        code = await new_dialog(repo, initiator_id=message.from_user.id, target_id=target_id, kind="user")
+        sender_pref = await repo.get_anon_pref_mode(message.from_user.id)
+        if sender_pref == "reject":
+            await message.answer(tr(lang_code, "Вы отключили анонимные чаты. Сначала включите их в настройках.", "You disabled anonymous chats. Enable them in settings first."))
+            return
+        target_pref = await repo.get_anon_pref_mode(target_id)
+        if target_pref == "reject":
+            await message.answer(tr(lang_code, "Пользователь отключил анонимные чаты.", "The user disabled anonymous chats."))
+            return
+        target_consent = "pending" if target_pref == "confirm" else "approved"
+        code = await new_dialog(
+            repo,
+            initiator_id=message.from_user.id,
+            target_id=target_id,
+            kind="user",
+            target_consent=target_consent,
+        )
     await state.set_state(AnonStates.dialog_message)
     await state.update_data(dialog_code=code, kind="user")
     await message.answer(tr(lang_code, f"Диалог #{code} создан. Отправь первое сообщение.", f"Dialog #{code} is created. Send the first message."))
@@ -83,29 +107,121 @@ async def on_dialog_message(message: Message, state: FSMContext, session_maker: 
 
     async with session_maker() as session:
         repo = Repo(session)
-        dialog = await repo.get_anon_dialog_by_code(dialog_code)
-        if not dialog or dialog.status != "active":
+        dialog_row = await repo.get_anon_dialog_by_code(dialog_code)
+        if not dialog_row or dialog_row.status != "active":
             await state.clear()
             await message.answer(tr(lang_code, "Диалог уже закрыт.", "This dialog is closed."))
             return
-        dialog = snapshot(dialog)
+        dialog = snapshot(dialog_row)
         if message.from_user.id not in (dialog.initiator_id, dialog.target_id):
             await message.answer(tr(lang_code, "Ты не участник диалога.", "You are not a participant."))
             return
         recipient = dialog.target_id if dialog.initiator_id == message.from_user.id else dialog.initiator_id
-        await repo.add_anon_message(dialog_id=dialog.id, sender_id=message.from_user.id, recipient_id=recipient, text=message.text.strip())
+        cancel_reply_timeout(dialog.id, message.from_user.id)
+        await _deliver_user_message(
+            message=message,
+            dialog=dialog,
+            repo=repo,
+            recipient_id=recipient,
+            text=message.text.strip(),
+            session_maker=session_maker,
+        )
 
+
+async def _deliver_user_message(
+    *,
+    message: Message,
+    dialog,
+    repo: Repo,
+    recipient_id: int,
+    text: str,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    lang_code = lang(message.from_user.id)
+    sender_mode = await repo.get_anon_pref_mode(message.from_user.id)
+    if sender_mode == "reject":
+        await message.answer(self_blocked_text(lang_code))
+        await repo.close_anon_dialog(dialog.id)
+        cancel_all_timeouts(dialog.id)
+        await notify_dialog_closed(message.bot, dialog, message.from_user.id)
+        return
+    recipient_mode = await repo.get_anon_pref_mode(recipient_id)
+    role = dialog_role(dialog, recipient_id, as_recipient=True)
+    consent_status = dialog.target_consent if role == "target" else dialog.initiator_consent
+    if recipient_mode == "reject":
+        await message.answer(receiver_blocked_text(lang_code))
+        await repo.close_anon_dialog(dialog.id)
+        cancel_all_timeouts(dialog.id)
+        await notify_dialog_closed(message.bot, dialog, message.from_user.id)
+        return
+    pending_request = None
+    if recipient_mode == "confirm":
+        if consent_status == "rejected":
+            await message.answer(tr(lang_code, "Собеседник отклонил этот диалог.", "The recipient declined this chat."))
+            return
+        pending_request = await repo.get_pending_consent_request(dialog.id, recipient_id)
+        if pending_request:
+            await message.answer(awaiting_consent_text(lang_code))
+            return
+    should_request_consent = recipient_mode == "confirm" and consent_status != "approved"
+    with_header = should_show_header(dialog, recipient_id)
+    if should_request_consent:
+        msg = await repo.add_anon_message(
+            dialog_id=dialog.id,
+            sender_id=message.from_user.id,
+            recipient_id=recipient_id,
+            text=text,
+            delivered=False,
+        )
+        await repo.set_dialog_consent(dialog.id, role, "pending")
+        request = await repo.create_consent_request(
+            dialog_id=dialog.id,
+            recipient_id=recipient_id,
+            pending_message_id=msg.id,
+            placeholder_message_id=0,
+        )
+        recipient_lang = lang(recipient_id)
+        placeholder = await message.bot.send_message(
+            recipient_id,
+            consent_prompt_text(dialog.dialog_code, recipient_lang),
+            reply_markup=consent_keyboard(request.id, recipient_lang),
+            parse_mode=ParseMode.HTML,
+        )
+        await repo.update_consent_placeholder(request.id, placeholder.message_id)
+        if with_header:
+            await repo.mark_dialog_header_sent(dialog.id, role)
+        await message.answer(awaiting_consent_text(lang_code))
+        return
+
+    msg = await repo.add_anon_message(
+        dialog_id=dialog.id,
+        sender_id=message.from_user.id,
+        recipient_id=recipient_id,
+        text=text,
+        delivered=True,
+    )
     delivered = await send_dialog_message(
         bot=message.bot,
         dialog=dialog,
-        recipient_id=recipient,
-        text=message.text,
-        lang_code=lang(recipient),
+        recipient_id=recipient_id,
+        text=text,
+        lang_code=lang(recipient_id),
+        with_header=with_header,
     )
     if not delivered:
         await message.answer(tr(lang_code, "Не удалось доставить сообщение.", "Failed to deliver the message."))
-    else:
-        await message.answer(tr(lang_code, "Отправлено.", "Delivered."))
+        return
+    if with_header:
+        await repo.mark_dialog_header_sent(dialog.id, role)
+    await message.answer(tr(lang_code, "Отправлено.", "Delivered."))
+    schedule_reply_timeout(
+        dialog,
+        waiting_for=recipient_id,
+        message_id=msg.id,
+        last_sender_id=message.from_user.id,
+        bot=message.bot,
+        session_maker=session_maker,
+    )
 
 
 @router.callback_query(DialogCB.filter())
@@ -138,6 +254,7 @@ async def dialog_callback(
         async with session_maker() as session:
             repo = Repo(session)
             await repo.close_anon_dialog(dialog.id)
+        cancel_all_timeouts(dialog.id)
         await state.clear()
         await notify_dialog_closed(callback.bot, dialog, callback.from_user.id)
         await callback.message.answer(tr(lang_code, "Диалог закрыт.", "Dialog closed."))
@@ -154,6 +271,7 @@ async def cmd_exit(message: Message, state: FSMContext, session_maker: async_ses
             await message.answer(tr(lang_code, "Нет активных диалогов.", "No active dialog."))
             return
         await repo.close_anon_dialog(dialog.id)
+    cancel_all_timeouts(dialog.id)
     await state.clear()
     await notify_dialog_closed(message.bot, dialog, message.from_user.id)
     await message.answer(tr(lang_code, "Диалог закрыт.", "Dialog closed."))

--- a/src/bot/handlers/anon/menu.py
+++ b/src/bot/handlers/anon/menu.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from aiogram import Router, F
 from aiogram.filters import Command
+from aiogram.filters.command import CommandObject
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, Message
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from bot.utils.repo import Repo
 
@@ -17,9 +18,15 @@ from .common import (
     ensure_rate,
     lang,
     main_admin_id,
+    new_dialog,
     notify_dialog_closed,
+    receiver_blocked_text,
+    resolve_target,
+    self_blocked_text,
+    snapshot,
     tr,
 )
+from .dialogs import _deliver_user_message
 from .states import AnonStates
 
 router = Router(name="anon-menu")
@@ -50,13 +57,23 @@ def _menu_keyboard(lang_code: str, has_dialog: bool) -> InlineKeyboardBuilder:
         kb.button(text=tr(lang_code, "🚪 Завершить диалог", "🚪 Close dialog"), callback_data=MenuCB(action="dialog_close").pack())
     kb.button(text=tr(lang_code, "🛎 Сообщение админам", "🛎 Message admins"), callback_data=MenuCB(action="admins").pack())
     kb.button(text=tr(lang_code, "📣 В общий чат", "📣 Public chat"), callback_data=MenuCB(action="public").pack())
+    kb.button(text=tr(lang_code, "⚙️ Настройки", "⚙️ Settings"), callback_data=MenuCB(action="settings").pack())
     kb.adjust(1)
     return kb
 
 
 @router.message(Command("anon"))
-async def cmd_anon(message: Message, state: FSMContext, session_maker: async_sessionmaker[AsyncSession]) -> None:
+async def cmd_anon(
+    message: Message,
+    state: FSMContext,
+    session_maker: async_sessionmaker[AsyncSession],
+    command: CommandObject | None = None,
+) -> None:
     await state.clear()
+    if command and (command.args or "").strip():
+        handled = await _handle_direct_command(message, state, session_maker, command.args.strip())
+        if handled:
+            return
     lang_code = lang(message.from_user.id)
     async with session_maker() as session:
         repo = Repo(session)
@@ -126,3 +143,69 @@ async def cb_public(callback: CallbackQuery, state: FSMContext) -> None:
     await state.set_state(AnonStates.public_message)
     await callback.message.answer(tr(lang_code, "Напиши текст для публикации. Админы одобрят или отклонят.", "Send the text you want to publish. Admins will approve or reject it."))
     await callback.answer()
+
+
+async def _handle_direct_command(
+    message: Message,
+    state: FSMContext,
+    session_maker: async_sessionmaker[AsyncSession],
+    raw_args: str,
+) -> bool:
+    lang_code = lang(message.from_user.id)
+    args = (raw_args or "").strip()
+    if not args:
+        return False
+    parts = args.split(maxsplit=1)
+    target_raw = parts[0]
+    body = parts[1].strip() if len(parts) > 1 else ""
+    if not body:
+        await message.answer(tr(lang_code, "Добавь текст сообщения после ID или username.", "Add the message text after the ID or username."))
+        return True
+    async with session_maker() as session:
+        repo = Repo(session)
+        try:
+            target_id = await resolve_target(repo, target_raw)
+        except ValueError:
+            await message.answer(tr(lang_code, "Не удалось определить пользователя.", "Could not resolve the user."))
+            return True
+        if not target_id:
+            await message.answer(tr(lang_code, "Укажи корректный ID или @username.", "Provide a valid ID or @username."))
+            return True
+        try:
+            await ensure_rate(message.from_user.id, lang_code)
+        except ValueError as err:
+            await message.answer(str(err))
+            return True
+        existing = await active_dialog(repo, message.from_user.id, kind="user")
+        if existing:
+            await message.answer(tr(lang_code, "Сначала завершите текущий диалог.", "Please close the active dialog first."))
+            return True
+        sender_pref = await repo.get_anon_pref_mode(message.from_user.id)
+        if sender_pref == "reject":
+            await message.answer(self_blocked_text(lang_code))
+            return True
+        target_pref = await repo.get_anon_pref_mode(target_id)
+        if target_pref == "reject":
+            await message.answer(receiver_blocked_text(lang_code))
+            return True
+        target_consent = "pending" if target_pref == "confirm" else "approved"
+        code = await new_dialog(
+            repo,
+            initiator_id=message.from_user.id,
+            target_id=target_id,
+            kind="user",
+            target_consent=target_consent,
+        )
+        dialog_row = await repo.get_anon_dialog_by_code(code)
+        dialog = snapshot(dialog_row)
+        await state.set_state(AnonStates.dialog_message)
+        await state.update_data(dialog_code=dialog.dialog_code, kind="user")
+        await _deliver_user_message(
+            message=message,
+            dialog=dialog,
+            repo=repo,
+            recipient_id=dialog.target_id,
+            text=body,
+            session_maker=session_maker,
+        )
+    return True

--- a/src/bot/handlers/anon/settings.py
+++ b/src/bot/handlers/anon/settings.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from aiogram import Router, F
+from aiogram.types import CallbackQuery
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from bot.utils.repo import Repo
+
+from .callbacks import MenuCB, PrefCB
+from .common import (
+    active_dialog,
+    cancel_all_timeouts,
+    lang,
+    notify_dialog_closed,
+    pref_label,
+    tr,
+)
+
+router = Router(name="anon-settings")
+
+
+@router.callback_query(MenuCB.filter(F.action == "settings"))
+async def cb_settings(callback: CallbackQuery, session_maker: async_sessionmaker[AsyncSession]) -> None:
+    lang_code = lang(callback.from_user.id)
+    async with session_maker() as session:
+        repo = Repo(session)
+        mode = await repo.get_anon_pref_mode(callback.from_user.id)
+    kb = InlineKeyboardBuilder()
+    for value in ("auto", "confirm", "reject"):
+        kb.button(
+            text=("✅ " if mode == value else "• ") + pref_label(value, lang_code),
+            callback_data=PrefCB(mode=value).pack(),
+        )
+    kb.button(text=tr(lang_code, "⬅️ Назад", "⬅️ Back"), callback_data=MenuCB(action="menu").pack())
+    kb.adjust(1)
+    text = tr(
+        lang_code,
+        "⚙️ <b>Настройки анонимных чатов</b>\n\n"
+        "Выбери режим обработки входящих чатов:\n"
+        "1. Автопринятие.\n"
+        "2. Нужна ручная проверка — придёт запрос «принять / отклонить».\n"
+        "3. Полный отказ (нельзя отправлять и получать).\n\n"
+        f"Текущий режим: <b>{pref_label(mode, lang_code)}</b>.",
+        "⚙️ <b>Anonymous chat settings</b>\n\n"
+        "Choose how to handle incoming chats:\n"
+        "1. Auto accept.\n"
+        "2. Require confirmation (you'll get Accept / Decline buttons).\n"
+        "3. Decline everything (you also can't send chats).\n\n"
+        f"Current mode: <b>{pref_label(mode, lang_code)}</b>.",
+    )
+    await callback.message.edit_text(text, reply_markup=kb.as_markup())
+    await callback.answer()
+
+
+@router.callback_query(PrefCB.filter())
+async def cb_set_pref(
+    callback: CallbackQuery,
+    callback_data: PrefCB,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    lang_code = lang(callback.from_user.id)
+    mode = callback_data.mode
+    if mode not in {"auto", "confirm", "reject"}:
+        await callback.answer("Unknown option", show_alert=True)
+        return
+    dialog = None
+    async with session_maker() as session:
+        repo = Repo(session)
+        await repo.set_anon_pref_mode(callback.from_user.id, mode)
+        dialog = await active_dialog(repo, callback.from_user.id, kind="user")
+        if mode == "reject" and dialog:
+            await repo.close_anon_dialog(dialog.id)
+            cancel_all_timeouts(dialog.id)
+    if mode == "reject" and dialog:
+        await notify_dialog_closed(callback.bot, dialog, callback.from_user.id)
+    await callback.answer(tr(lang_code, "Режим обновлён.", "Preference updated."))
+    await cb_settings(callback, session_maker)

--- a/src/bot/models/__init__.py
+++ b/src/bot/models/__init__.py
@@ -14,6 +14,8 @@ from .models import (
     AnonDialog,
     AnonMessage,
     AnonPublicRequest,
+    AnonPreference,
+    AnonConsentRequest,
     FireIncident,
     FireCounter,
 )
@@ -29,6 +31,8 @@ __all__ = [
     "AnonDialog",
     "AnonMessage",
     "AnonPublicRequest",
+    "AnonPreference",
+    "AnonConsentRequest",
     "FireIncident",
     "FireCounter",
 ]

--- a/src/bot/models/models.py
+++ b/src/bot/models/models.py
@@ -186,6 +186,10 @@ class AnonDialog(Base):
     status = Column(String, nullable=False, server_default=sa_text("'active'"))
     created_at = Column(String, nullable=False, server_default=sa_text("(CURRENT_TIMESTAMP)"))
     closed_at = Column(String, nullable=True)
+    initiator_header_sent = Column(Integer, nullable=False, server_default=sa_text("0"))
+    target_header_sent = Column(Integer, nullable=False, server_default=sa_text("0"))
+    initiator_consent = Column(String, nullable=False, server_default=sa_text("'approved'"))
+    target_consent = Column(String, nullable=False, server_default=sa_text("'approved'"))
 
 
 class AnonMessage(Base):
@@ -200,6 +204,7 @@ class AnonMessage(Base):
     recipient_id = Column(BigInteger, nullable=False)
     text = Column(Text, nullable=False)
     created_at = Column(String, nullable=False, server_default=sa_text("(CURRENT_TIMESTAMP)"))
+    is_delivered = Column(Integer, nullable=False, server_default=sa_text("1"))
 
 
 class AnonPublicRequest(Base):
@@ -216,6 +221,33 @@ class AnonPublicRequest(Base):
     processed_at = Column(String, nullable=True)
     processed_by = Column(BigInteger, nullable=True)
     reason = Column(Text, nullable=True)
+
+
+class AnonPreference(Base):
+    """
+    Настройки анонимных чатов для пользователя.
+    """
+    __tablename__ = "anon_preferences"
+
+    user_id = Column(BigInteger, primary_key=True)
+    mode = Column(String, nullable=False, server_default=sa_text("'auto'"))  # auto|confirm|reject
+    updated_at = Column(String, nullable=False, server_default=sa_text("(CURRENT_TIMESTAMP)"))
+
+
+class AnonConsentRequest(Base):
+    """
+    Запрос подтверждения для получения анонимного сообщения.
+    """
+    __tablename__ = "anon_consent_requests"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    dialog_id = Column(Integer, ForeignKey("anon_dialogs.id", ondelete="CASCADE"), index=True, nullable=False)
+    recipient_id = Column(BigInteger, nullable=False, index=True)
+    placeholder_message_id = Column(BigInteger, nullable=False)
+    pending_message_id = Column(Integer, ForeignKey("anon_messages.id", ondelete="CASCADE"), nullable=False)
+    status = Column(String, nullable=False, server_default=sa_text("'pending'"))  # pending|approved|rejected
+    created_at = Column(String, nullable=False, server_default=sa_text("(CURRENT_TIMESTAMP)"))
+    responded_at = Column(String, nullable=True)
 
 
 class FireIncident(Base):

--- a/src/bot/services/anon.py
+++ b/src/bot/services/anon.py
@@ -60,6 +60,10 @@ class DialogSnapshot:
     target_id: int
     kind: str
     status: str
+    initiator_header_sent: int
+    target_header_sent: int
+    initiator_consent: str
+    target_consent: str
 
 
 def snapshot(dialog) -> DialogSnapshot:
@@ -72,6 +76,10 @@ def snapshot(dialog) -> DialogSnapshot:
         target_id=dialog.target_id,
         kind=getattr(dialog, "kind", "user"),
         status=getattr(dialog, "status", "active"),
+        initiator_header_sent=int(getattr(dialog, "initiator_header_sent", 0) or 0),
+        target_header_sent=int(getattr(dialog, "target_header_sent", 0) or 0),
+        initiator_consent=getattr(dialog, "initiator_consent", "approved"),
+        target_consent=getattr(dialog, "target_consent", "approved"),
     )
 
 
@@ -91,10 +99,7 @@ async def resolve_user_identifier(raw: str) -> Optional[int]:
     if not candidate:
         return None
     if candidate.startswith("@"):
-        info = await asyncio.to_thread(UserInfoSource().get_user_info, candidate.lstrip("@"))
-        if "id" not in info:
-            raise ValueError("User not found")
-        return int(info["id"])
+        raise ValueError("username_lookup_disabled")
     return int(candidate)
 
 


### PR DESCRIPTION
**Summary**

  - New user-facing settings for anonymous chats (/anon → ⚙ Settings): auto-accept, confirmation,
    or full rejection. Confirm mode sends inline “Accept / Decline” prompts before a message is
    delivered; reject mode blocks both sending and receiving.
  - Anonymous dialog storage now keeps consent status, header flags, and pending requests (new
    AnonPreference + AnonConsentRequest tables). Users can start chats via /anon @username message
    using only IDs/usernames from our DB; the first message auto-sends, headers appear only once
    per participant, and dialogs auto-close if nobody answers for 15 minutes.
  - Admin panel gains an “🕵️ Анонимные чаты” section with paginated list and per-dialog view (with
    recent messages). Buttons let admins page through dialogs and inspect message history without
    leaving Telegram.

  **Deployment Notes**

  - No manual migrations: Base.metadata.create_all will add the new tables/columns on startup.
  - Ensure .env still contains MAIN_ADMIN_ID and TARGET_CHAT_ID.

  **Testing**

  - /anon flows: settings screen, auto-accept vs confirm, reject mode, /anon @username text, slash
    reply flow, timeout auto-close.
  - Admin panel: “🕵️ Анонимные чаты” list/page navigation, dialog detail view, message pagination.